### PR TITLE
PMueller solution

### DIFF
--- a/parser.rb
+++ b/parser.rb
@@ -1,3 +1,3 @@
 def word_in_string?(word, string)
-  # implement with your code here
+  string.match(/(?<=(?:\W|_|^))#{word}(?=(?:\W|_|$))/) ? :yes : :no
 end


### PR DESCRIPTION
Didn't want to split the string, as other characters would need to be added to the splitting characters if more options were added. Regex made the most sense to me.
